### PR TITLE
Fixes #8, fixes #9 update xml with placeholder elements

### DIFF
--- a/output/d1.1.xml
+++ b/output/d1.1.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d1.1.xml
+++ b/output/d1.1.xml
@@ -42,7 +42,15 @@
                     <lb/>east face of pier a11, in black Ink. dimensions 23 cm wide × 40 cm high.
                     <lb/>dipinto of the bust of a gladiator located at the eastern face of pier a11, looking into Bay 1. The ink is mostly faded. The bust, seen from behind, is drawn in three-quarter, turned to the left. The image can be identified as a large crested gladiatorial helmet and a breastplate that covers also part of the back. The dipinto was probably meant to be a close-up of the gladiator depicted in D1.2.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d1.2.xml
+++ b/output/d1.2.xml
@@ -42,7 +42,15 @@
                     <lb/>on the east face of pier a11, in black ink. dimensions 18 cm wide × 18 cm high.
                     <lb/>dipinto of a gladiator located at the eastern face of pier a11, looking into Bay 1. highly sche- matic, it depicts a gladiator seen in profile, advancing to the left. while the head and legs are drawn in profile, the torso is frontal. The man wears a brimmed and crested helmet and pos- sibly a long breastplate. his arms are extended to the sides: he holds in both a short weapon, interpretable either as a sword terminating in a semi-circular blade or as a semi-circular blade attached to a tang or metal shaft, possibly an arbelos. The detail of the weapons suggests that the gladiator can be identified as a διμάχαιρος or even an ἀρβήλαϛ, seldom depicted on funerary stelae or official reliefs. a similar but shorter version of the weapon is visible on the tombstone relief of the gladiator Myron, now at the louvre Museum (inv. Ma 154) and dated to the sec- ond–third century CE. while it is impossible to identify on the smyrna graffito the scaled tunic worn by Myron, the helmet, with its high crest and wide brims, is clearly identical to the one on the tombstone. The louvre relief has no certain provenance, but it has been known since 1806. louis robert, the first to provide a full description of its iconography, interpreted the weapon as a metal cone terminating in a crescent that was meant to be used by a retiarius to attach his net (robert 1940: no. 299, pp. 235–6). The smyrna graffito ultimately disproves his hypothesis. a discussion on the role and the weapons of the arbelas appears in carter 2001: 109–15, esp. 112–3, fig. 2.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d1.2.xml
+++ b/output/d1.2.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d1.3.xml
+++ b/output/d1.3.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d1.3.xml
+++ b/output/d1.3.xml
@@ -42,7 +42,15 @@
                     <lb/>In the upper right quadrant of Bay 1, in red and black ink. dimensions 20 cm wide × 27 cm high.
                     <lb/>dipinto of a male bust located at the upper right quadrant of the back wall of Bay 1. The draw- ing is mostly made in red ink. Black strokes, visible in the dipinto’s lower half, could have served as preparatory guidelines. The head and shoulders are fully frontal. The man wears a short hairstyle, with slightly wavy hair falling on the forehead. he has a long, full, and wavy beard that starts from below his pointed ears and terminates, at the center of the chin, in a pointed tip. Thin mustaches are visible above the upper lip. The mouth is small and the lips are thin. The nose is straight and the large eyes, with marked pupils, are asymmetrical and almond- shaped. The eyebrows are linear and heavily marked in red. The large neck is visibly elongated, with a central long line suggesting its fullness. at its base, a simple line indicates the tunic’s rounded rim.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d1.4.xml
+++ b/output/d1.4.xml
@@ -52,7 +52,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d1.4.xml
+++ b/output/d1.4.xml
@@ -43,7 +43,15 @@
                     <lb/>× 26 cm high.
                     <lb/>dipinto of an ivy leaf. The leaf, pointing downward, is heart-shaped with its left half consid- erably larger than the right one. a long, slightly curved petiole extends toward the right and terminates with a butterfly-shaped pulvinus.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d10.1.xml
+++ b/output/d10.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d10.1.xml
+++ b/output/d10.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d11.1.xml
+++ b/output/d11.1.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d11.1.xml
+++ b/output/d11.1.xml
@@ -42,7 +42,15 @@
                     <lb/>In the center, right half, of the bay, in black and red ink. dimensions 73 cm wide × 38.5 cm high. published as Bay 11-t22 in pomey 2006: 330–1, fig. 22.
                     <lb/>dipinto of the hull of a ship sailing on starboard tack, located in the right half of the back wall of Bay 11, toward the center. while no traces are left of the mast, yard, or sails, the hull is clearly defined by a distinct red line used for the overall outline. The ship’s body is colored in with a pattern of large x-shaped marks that become smaller and closer toward the prow, where they create a checkerboard motif that defines a raised platform. This structure, interpretable as a forecastle formed of crossed spars, must have stretched all the way to the mast, but it is now faded. no oars or oarports are visible, and the keel is flat. above the prow is a zigzag motif in black, not outlined in red like the rest of the dipinto, indicating a later addition or the artist’s afterthought. It can be identified as a stylized στόλος, with the ἀκροστόλιον possibly meant to represent a swan’s neck. The stern is very high and straight, as in some representations of cor- bitae onerariae of the period.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d11.2.xml
+++ b/output/d11.2.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d11.2.xml
+++ b/output/d11.2.xml
@@ -42,7 +42,15 @@
                     <lb/>In the upper right quadrant of the bay, in black ink. dimensions 16 cm wide × 18 cm high.
                     <lb/>dipinto of a gladiator holding the palm of victory, located in the upper right quadrant of the back wall of Bay 11. due to the lack of any helmet or shield and the presence of a subligaculum it is possible to recognize in the figure a retiarus. The lines on the left arm suggest the presence of a manica (arm-guard), while the plate across his back is a galerus, a tall metal guard protect- ing the shoulder. The very faded lines that descend from the right shoulder of the gladiator reaching down toward the ground could represent what is preserved of the net. The gladiator is depicted as striding forward toward the left, with the groundline below his feet defined by several thick streaks. The man has his back to the viewer and the face in profile, the chin and nose accentuated and the hair rendered in flowing curls.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d11.3.xml
+++ b/output/d11.3.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d11.3.xml
+++ b/output/d11.3.xml
@@ -42,7 +42,15 @@
                     <lb/>In the upper right quadrant of the bay, in black ink. dimensions not recorded.
                     <lb/>dipinto of a gladiator, located in the upper right quadrant of the back wall of Bay 11. The lines are very faded, making the drawing very difficult to read. The figure, in three-quarter, is shown as advancing to the left, with the left leg stretched forward. The head seems to be covered by a brimmed helmet, while the upper part of the body is covered by a large shield that reaches down to the knees only. These two elements suggest that the gladiator might have been a provocator.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d11.4.xml
+++ b/output/d11.4.xml
@@ -42,7 +42,15 @@
                     <lb/>In the lower right quadrant of the bay, in black ink. dimensions 2 cm wide × 12 cm high.
                     <lb/>schematic dipinto of a human head, possibly male, located in the lower right quadrant of the back wall of Bay 11. The head is depicted in profile, with a prominent and round forehead, long pointed nose, small mouth with a triangular upper lip, and an oval slanted eye. The upper part of the head is faded, so it difficult to recognize any hairdo.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d11.4.xml
+++ b/output/d11.4.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d11.5.xml
+++ b/output/d11.5.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>In the upper right quadrant of the bay, in black ink. dimensions 59 cm wide × 26 cm high. dipinto of a male sexual organ, located in the upper right quadrant of the back wall of Bay</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d11.5.xml
+++ b/output/d11.5.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d11.6.xml
+++ b/output/d11.6.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d11.6.xml
+++ b/output/d11.6.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d14.2.xml
+++ b/output/d14.2.xml
@@ -42,7 +42,15 @@
                     <lb/>on the west face of pier a25, in black ink. dimensions 32 cm wide × 32 cm high.
                     <lb/>dipinto of a ship, possibly a corbita, located on the western face of pier a25, looking into Bay</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d14.2.xml
+++ b/output/d14.2.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d15.5.xml
+++ b/output/d15.5.xml
@@ -43,7 +43,15 @@
                     <lb/>dipinto of a gladiator, located in the upper left quadrant of the back wall of Bay 14. The man, depicted in a three-quarter view, has his back toward the viewer. only the upper portion of the body, down to the hips, is visible, while the lower half is completely effaced. The gladiator is portrayed in the act of stretching his right arm forward. he holds a short sword, whose con- tours are now almost entirely faded. at his waist a balteus is recognizable, and to his left side is a tall scutum. The crest on the helmet and the long flange protecting the neck indicate that the gladiator is probably a secutor.
                     <lb/>The iconography of this helmet is typical of gladiatorial reliefs from smyrna, as demonstrated by a very close parallel in a funerary stele from smyrna: robert 1940: 203 no. 226.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d15.5.xml
+++ b/output/d15.5.xml
@@ -52,7 +52,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d15.6.xml
+++ b/output/d15.6.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d15.6.xml
+++ b/output/d15.6.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d16.1.xml
+++ b/output/d16.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d16.1.xml
+++ b/output/d16.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d17.1.xml
+++ b/output/d17.1.xml
@@ -42,7 +42,15 @@
                     <lb/>In the center of the bay, in black and red ink. dimensions 167 cm wide × 120 cm high.
                     <lb/>very long dipinto in thick black and red lines, located at the center of the back wall of Bay 17. The shape, narrow and elongated, tapers at the two ends. a packed series of parallel straight lines are drawn within the form’s outline. a long line, parallel to the lower margin, runs throughout the whole width. other lines seem to have continued below the main outline, but they are now completely faded. The dipinto can be interpreted as a ship: two very faded lines at the center identify the tapering shape of a mast, decorated with two horizontal lines defining the ropes tied around it. This suggests that the upper portion of the drawing has to be understood as a furled sail. The bulwark and the keel are completely faded.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d17.1.xml
+++ b/output/d17.1.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d17.2.xml
+++ b/output/d17.2.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d17.2.xml
+++ b/output/d17.2.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d18.1.xml
+++ b/output/d18.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d18.1.xml
+++ b/output/d18.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d19.1.xml
+++ b/output/d19.1.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d19.1.xml
+++ b/output/d19.1.xml
@@ -42,7 +42,15 @@
                     <lb/>In the center of the upper register, in black ink. dimensions 68 cm × 33.5 cm.
                     <lb/>dipinto of a ship sailing on port tack located in the upper register of the back wall of Bay 19, toward the center of the wall. It most probably represents a medium sized merchant vessel (a corbita?). The graffito is very damaged: the whole upper half of the ship with the yard and sail is missing, and only the lower portions of the mast and the rigging are visible. The hull is rounded and the keel is strongly rockered. no deck is visible, but toward the prow a light structure might suggest the presence of a forecastle. a line running along the hull, roughly at its middle, indi- cates the ship’s waterway. at the stern, the two πηδάλια, raised from the water, are rendered with two very thick parallel lines. roughly parallel to them is a series of one, possibly two, rows of oars (κῶπαι; at least 20 are still recognizable) drawn as long, slightly diagonal lines each terminating in a circle. neither the aplustre or the στόλος is identifiable.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d19.2.xml
+++ b/output/d19.2.xml
@@ -55,7 +55,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d19.2.xml
+++ b/output/d19.2.xml
@@ -46,7 +46,15 @@
                     <lb/>The use of the mappa in depictions of high officials is also well attested in large size statues of proconsuls, like the sixth-century marble statue of stephanos, proconsul of ephesos, found in the street of the curetes and now at the selçuk Museum in ephesos, or the statues of pytheas and palmatus found, respectively, in the bouleuterion and in the west colonnade of the tetra- stoon square at aphrodisias, both dated to the late fifth century. These comparisons, together with some stylistic traits of the smyrna dipinto, seem to suggest a dating of the dipinto to the late fourth–early fifth century CE.
                     <lb/>Basic information on the ivory diptychs may be found in eastmond 2010 and olovsdotter 2011. for a use of the diptychs also by senators see engemann 2008. on the proconsular statues see smith 1999: 167–9.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d19.3.xml
+++ b/output/d19.3.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d19.3.xml
+++ b/output/d19.3.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d20.1.xml
+++ b/output/d20.1.xml
@@ -42,7 +42,15 @@
                     <lb/>In the upper right quadrant of the bay, in black ink. dimensions 9 cm wide × 9 cm high.
                     <lb/>dipinto of two human heads, possibly males, located on the back wall of Bay 20, in the upper right quadrant. This graffito is in very poor condition: large lacunae in the plaster and wide- spread fading make it difficult to identify the figures. to the left is a face, possibly in profile, looking to the right. The oval of the face and the wavy shoulder-length hair are the more rec- ognizable elements. The head to the right is fully frontal. Most of the details have disappeared; however, notable is the hairdo of curly hair on which lies a wreath.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d20.1.xml
+++ b/output/d20.1.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d21.1.xml
+++ b/output/d21.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d21.1.xml
+++ b/output/d21.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d22.1.xml
+++ b/output/d22.1.xml
@@ -52,7 +52,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d22.1.xml
+++ b/output/d22.1.xml
@@ -43,7 +43,15 @@
                     <lb/>dipinto of a human bust, located in the western half of the back wall of Bay 22, toward the middle. The head, possibly of a female, is drawn in profile toward the left, and the bust is cut short right below the shoulders. The figure has an up hairdo consistent with late second century fashion: in the front the hair is wavy and descends to cover the forehead, while at the back the hairs are gathered together in a bun fastened with a fillet. The woman in the graffito is depicted with a rather long, “roman” nose, thick and protruding lips, and round and prominent chin. The large, almond-shaped eye, positioned near the hair line, is completed with eyelashes and a pupil which is turned to look directly at the viewer.
                     <lb/>similar hairstyles are attested on portraits of faustina the younger, like the one at Musei capi- tolini in rome dated to 147–148, or of Bruttia crispina, like the head at the altes Museum, Ber- lin, dated to 178–180. Basic information on portraits of these two roman queens can be found in Kleiner 1992: 277–80.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d22.2.xml
+++ b/output/d22.2.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d22.2.xml
+++ b/output/d22.2.xml
@@ -42,7 +42,15 @@
                     <lb/>In the western half of the bay, in black ink. dimensions 38 cm wide × 49 cm high.
                     <lb/>dipinto of a gladiatorial combat, located in the western half of the back wall of Bay 22, toward the middle. The drawing is damaged by a very large lacuna at the right half, so that only the gladiator to the left is still preserved. he is drawn in three-quarter, his head and body turned toward the right. The head of the gladiator is completely covered by a tight fitting, visored hel- met. The chest is protected by a semicircular breastplate. The right arm is bent forward: he is probably holding his weapon, but the lines here are almost completely faded.  to the right are a few traces of the other figure: a rectangular shield and the brim of the helmet protecting the neck. The lower half of the body of both men is missing (and probably was never drawn). con- sidering the secure identification of the left gladiator as a provocator, the scene can be identified as a combat between provocatores.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d24.2.xml
+++ b/output/d24.2.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d24.2.xml
+++ b/output/d24.2.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d27.1.xml
+++ b/output/d27.1.xml
@@ -45,7 +45,15 @@
                     <lb/>This first ship seems to relate to the text T27.1.
                     <lb/>The lower and later vessel’s stern is not completely preserved, while at the prow is recognizable a rounded στόλος pointing inward. no mast, yard, sails or oars are identifiable for this second ship.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d27.1.xml
+++ b/output/d27.1.xml
@@ -54,7 +54,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d27.2.xml
+++ b/output/d27.2.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d27.2.xml
+++ b/output/d27.2.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d29.1.xml
+++ b/output/d29.1.xml
@@ -43,7 +43,15 @@
                     <lb/>dipinto of a provocator, striding toward the right, located in the upper left quadrant of the back wall of Bay 29. recognizable are the characteristic greave above the knee on the left leg, the manica (arm-guard) on the right arm, the visored helmet with a large horizontal neck-guard, and the indication of a short, crescent-shaped breastplate. The shield has the typical curved rectangular shape with a boss at the center. The gladiator is holding in his right hand a short sword with a straight blade. he is depicted in the act of walking toward another figure to his right. considering the extreme stylization of such a figure, it is possibly meant to represent a palus carved in the rough shape of a human head and torso with which the provocator is train- ing. The graffito is partially obliterated by a later graffito of a bird (see D29.10).
                     <lb/>The iconographic details of this gladiator find close comparison in a gravestone from Kos dated to the third century CE (pfuhl and Möbius 1977: vol. 2, no. 1202, p. 296).</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d29.1.xml
+++ b/output/d29.1.xml
@@ -52,7 +52,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d29.10.xml
+++ b/output/d29.10.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d29.10.xml
+++ b/output/d29.10.xml
@@ -42,7 +42,15 @@
                     <lb/>In the upper left quadrant of the bay, in black ink. dimensions 23 cm wide × 21.5 cm high.
                     <lb/>dipinto of a bird, located in the upper left quadrant of the back wall of Bay 29. This graffito overlaps parts of graffito D29.1, suggesting that it was drawn at a later date (though it is impos- sible to determine any specific time lapse between the first and the second graffito). The bird is in profile and turned toward the right. possibly a dove, it has an elongated and pointed beak, a tall and round crown, and a rather large neck. The leaf-shaped right wing is located at the cen- ter of the body, its bottom characterized by a zig-zag motif that simulates the bird’s primaries. The tail is long and the round breast is clearly visible below the wing. one of the thighs, drawn diagonally, is well marked in thick lines, whereas the second one, possibly crossing the first one, is for the most part faded. The claw is drawn in foreshortening.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d29.11.xml
+++ b/output/d29.11.xml
@@ -43,7 +43,15 @@
                     <lb/>dipinto located on the eastern face of pier a40, looking into Bay 29. It comprises one gladiator and two palm branches, all partially damaged by lacunae in the plaster. The branch at the top is characterized by a long vertical line, the branch’s rachis, drawn in a thick streak. from this central line depart, at both sides, two corresponding sets of thirteen diagonal lines, the leaflets, progressively shorter at the top where the tip of the branch is situated. two short horizontal lines, one at the top and one at the bottom, complete the design.
                     <lb/>to the left of the branch is a very schematic depiction of a gladiator, of which only a visored helmet with a horizontal neck-guard and a large rectangular shield are visible. he can ten- tatively be identified as a provocator. at the bottom is a second palm branch composed of a central vertical line, from which departs a series of short diagonal lines (eight are still visible) alternately to the right and the left of the central axis. The palm branches are most certainly to be understood as complementing the image of the gladiator, who is thus to be considered as victorious.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d29.11.xml
+++ b/output/d29.11.xml
@@ -52,7 +52,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d29.12.xml
+++ b/output/d29.12.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d29.12.xml
+++ b/output/d29.12.xml
@@ -42,7 +42,15 @@
                     <lb/>on the east face of pier a40, in black ink. dimensions 17 cm wide × 18 cm high.
                     <lb/>dipinto of a male sexual organ, located on the eastern face of pier a40, looking into Bay 29. The ink is largely faded. of the upright corpus, only the left contour is still visible, made of a longer curved line and a few shorter ones next to it. Better preserved are the testicles: the left one is almost horizontal, flat at the top and concave at the bottom. an inner concave line gives the impression of three-dimensionality. The right testicle is larger and roughly oval. drawn diagonally, it is characterized by a double contour line that is similarly meant to convey dimensionality.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d29.13.xml
+++ b/output/d29.13.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d29.13.xml
+++ b/output/d29.13.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d29.2.xml
+++ b/output/d29.2.xml
@@ -53,7 +53,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d29.2.xml
+++ b/output/d29.2.xml
@@ -44,7 +44,15 @@
                     <lb/>back, and descending to the left foreleg. The body is extremely elongated and not very detailed. The tail is made of a single wavy line terminating in a small, upward tuft. The four legs are depicted as elongated inverted triangles terminating in small circles indicating the paws. The lion is mortally wounded: at its left flank a large spot of red ink indicates a wound from which blood, in long vertical lines, gushes out to cover the venator’s spear below.
                     <lb/>This scene is probably to be considered as the outcome of the fight between the venator and the feline taking place to the left (see D29.13).</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d29.3.xml
+++ b/output/d29.3.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d29.3.xml
+++ b/output/d29.3.xml
@@ -42,7 +42,15 @@
                     <lb/>In the center, upper register, of the bay, in black ink. dimensions 8 cm wide × 10 cm high.
                     <lb/>dipinto of a male head, located at the top of the back wall of Bay 29, toward the middle. The head is shown in profile, turned toward the left. The proportions and the poor detailing suggest that the drawing was not made by a trained artist. The head is characterized by a large almond- shaped eye with a round pupil and short eyebrow. The sharp acute line of the nose begins at the eye’s left corner. The upper lip is quite pronounced and the mouth is drawn as open. Below the undershot chin is a large, elongated neck. The hairline begins right above the eye, with no space left for the forehead. The hairdo is rendered in a few, thick parallel lines that follow the skull’s curvature, suggesting that the straight hair touched the nape of the neck. The ear is long and tear-shaped. The man might be a spectator, cf. T29.8</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d29.4.xml
+++ b/output/d29.4.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d29.4.xml
+++ b/output/d29.4.xml
@@ -42,7 +42,15 @@
                     <lb/>In the lower right quadrant of the bay, in black ink. dimensions 17 cm wide × 35 cm high.
                     <lb/>dipinto of a “stick figure,” located in the lower right quadrant of the back wall of Bay 29. The figure is depicted as fully frontal. Three Greek letters (Koe, see text T29.2) to the right of the head suggests that the figure, clearly drawn by an unskilled hand, is probably a stylized portrait of an individual carrying that Greek name or designation (which is, however, not securely identifiable). The head is a large oval sitting on a disproportionately elongated neck. There is no indication of a hairdo, and the facial features are limited to two round eyes, a few short lines for the eyelashes, and a long roman nose. The arms and the legs are in the shape of inverted triangles and there is no clear indication of hands or feet, apart from a very abraded left hand. The figure is dressed in a short tunica with a long diagonal line running on the front.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d29.5.xml
+++ b/output/d29.5.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d29.5.xml
+++ b/output/d29.5.xml
@@ -42,7 +42,15 @@
                     <lb/>In the lower left quadrant of the bay, in black ink. dimensions overall 18 cm wide × 13 cm high.
                     <lb/>very damaged dipinto of two heads in profile, located in the lower left quadrant of the back wall of Bay 29. Both are facing to the left. The head to the left is poorly preserved: the top is round and with no indication of hair. The neck, terminating in an inverted triangle, is quite elongated. a large almond-shaped eye is the only feature clearly distinguishable. The head to the right is slightly better preserved. a jeweled veil covers the top of the head (the jewels are rendered as lozenges), and the eye is round with clear indication of the eyebrow. The nose is pointed and the mouth possibly opened. The lower part of the graffito is badly damaged and illegible.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d29.6.xml
+++ b/output/d29.6.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d29.6.xml
+++ b/output/d29.6.xml
@@ -42,7 +42,15 @@
                     <lb/>In the lower right quadrant of the bay, in black ink. dimensions 25 cm wide × 31 cm high.
                     <lb/>very rudimentary dipinto of a “stick figure,” located in the lower right quadrant of the back wall of Bay 29. The outline is made of several thick lines that define a short and squat torso, short arms, and long legs. to the left of the figure is a small shield, rendered in thick, vertical lines. around the head of the figure, a wavy pattern might identify a wreath, suggesting that this is the representation of a victorious gladiator, a simplified version of dipinto D29.2.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d29.7.xml
+++ b/output/d29.7.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d29.7.xml
+++ b/output/d29.7.xml
@@ -42,7 +42,15 @@
                     <lb/>In the eastern half of the bay, in black ink. dimensions 52 cm wide × 52 cm high.
                     <lb/>large dipinto of a male sexual organ, located in the eastern half of the back wall of Bay 29. The corpus of the penis is drawn diagonally, with its tip at the upper right. It is composed of a diagonal line that terminates at the top in a large oval indicating the prepuce. The foreskin is further accentuated by a second concentric curved line. The corpus’ lower outline is defined by a short curved line that creates an overall teardrop shape. The two testicles are also placed diagonally. The outline of the right one, teardrop shaped, partially overlaps that of the corpus. The left testicle is barely sketched, with one broken line that suggests its position and size.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d29.8.xml
+++ b/output/d29.8.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d29.8.xml
+++ b/output/d29.8.xml
@@ -42,7 +42,15 @@
                     <lb/>on the west face of pier a41, in black ink. dimensions overall 27 cm wide × 51 cm high; of the bird, 20 cm wide × 24 cm high.
                     <lb/>dipinto of a venatio scene, located on the western face of pier a41, looking into Bay 29. The drawing is very rudimentary and schematic. at the bottom is a bird in profile, turned to the right. The bird, possibly a parrot, has a large head and beak, short crown, and a short and squat neck. Its body is entirely covered by the right wing, leaf-shaped and with a long line running at the center identifying the primary and secondary feathers. The tail is short and delineated by a single, thick line. The thigh is short and thin, and the claws are made in two parallel lines drawn in foreshortening. above it, two rectangular features to the right, one decorated with vertical lines, might represent the nets used to capture birds during the hunts. to the left is a linear feature terminating in an oval, possibly a lasso also used for bird-hunting.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d29.9.xml
+++ b/output/d29.9.xml
@@ -42,7 +42,15 @@
                     <lb/>In the lower right quadrant of the bay, in black ink. dimensions 30 cm wide × 35 cm high.
                     <lb/>dipinto of a bird, located in the lower right quadrant of the back wall of Bay 25. The bird, pos- sibly a dove, is drawn in thick black lines in profile, turned toward the right. It has a pointed beak, short crown, and a long and sinuous neck. The right, leaf-shaped wing is prominently displayed and constitutes the lower outline of the figure. a line runs at its center, schematically suggesting the feathers’ orientation. The tail feathers are barely indicated by two thicker lines. The bird has a very elongated and thin thigh, which terminates in a large triangle-shaped claw.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d29.9.xml
+++ b/output/d29.9.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d34.1.xml
+++ b/output/d34.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d34.1.xml
+++ b/output/d34.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d6.1.xml
+++ b/output/d6.1.xml
@@ -43,7 +43,15 @@
                     <lb/>dipinto of a ship sailing on starboard tack located in the upper left quadrant of the back wall of Bay 6. The ink has mostly disappeared: only faint traces of the strokes that defined the mast, the yard, and one sail are still visible, too ephemeral to allow any further description. The black lines in the right half of the dipinto are the best preserved, so that the stern of the ship is still recognizable. It is convex in shape and raised from the bulwark; a rectangular quarter- deck is positioned right above the stern, while a low ἄφλαστον, geometric and very simplified, terminates its upper portion. two rudders (πηδάλιοι) with large rectangular blades appear from both sides of the ship, but no other oars are visible. The ship’s prow, with an overly con- cave profile, is still somewhat visible at the left end of the dipinto. The black ink has for the most part disappeared: the lines are identifiable only from the discoloration of the portions of plaster that were originally covered by the color. The prow is surmounted by a rounded στόλος crowned by a spiral-shaped ἀκροστόλιον. a three-bladed ἔμβολος protrudes from the bottom of the prow, suggesting that the drawing was meant to represent a military vessel. considering the rather small size of the vessel, the dipinto was most probably meant to depict a navis rostrata (or liburna), one of the most common military vessels of the imperial period.
                     <lb/>a close comparison for the spiral-shaped acrostolium and the three-bladed rostrum in a sec- ond century CE sarcophagus from panderma. see pfuhl and Möbius 1977: vol. 1: 113, no. 283.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d6.1.xml
+++ b/output/d6.1.xml
@@ -52,7 +52,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d6.2.xml
+++ b/output/d6.2.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d6.2.xml
+++ b/output/d6.2.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d8.1.xml
+++ b/output/d8.1.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d8.1.xml
+++ b/output/d8.1.xml
@@ -42,7 +42,15 @@
                     <lb/>In the upper register of the bay, in black ink. dimensions 110 cm wide × 45.5 cm high.
                     <lb/>dipinto of a male sexual organ located on the back wall of Bay 8, toward the top. The corpus of the penis, damaged by a large lacuna toward the center, is rendered by two horizontal and roughly parallel lines. The area of the epithelium is indicated by a short diagonal line. The two testicles, drawn roughly as ovals, are placed to the sides of the corpus and are very close in size.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d8.2.xml
+++ b/output/d8.2.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d8.2.xml
+++ b/output/d8.2.xml
@@ -42,7 +42,15 @@
                     <lb/>In the right half of the center of the bay, in black ink. dimensions 79 cm wide × 23.5 cm high.
                     <lb/>dipinto of a male sexual organ located on the right half of the back wall of Bay 8, toward the middle. The corpus of the penis is rendered by a lower straight line and an upper curving one. The area of the epithelium is indicated by a short vertical line departing at two-thirds of the corpus’ length. a series of concentric lines outline the round testicles, the lower one slightly bigger in size. positioned at the two sides of the corpus, they are clearly separated from it and from each other.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d8.3.xml
+++ b/output/d8.3.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d8.3.xml
+++ b/output/d8.3.xml
@@ -42,7 +42,15 @@
                     <lb/>In the center of the bay, in black ink. dimensions 86 cm wide × 38 cm high.
                     <lb/>dipinto of a ship located on the back wall of Bay 8, toward the center. The drawing is partially obliterated by other graffiti, with the result that its full outline is not completely reconstruct- ible. The ship, sailing on port tack, has a concave keel terminating in a very high prow with a short, pointed στόλος. at the stern are visible two short πηδάλια, filled in with black color. no indication of mast, sails, or oars is visible.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d8.4.xml
+++ b/output/d8.4.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d8.4.xml
+++ b/output/d8.4.xml
@@ -42,7 +42,15 @@
                     <lb/>In the lower right quadrant of the bay, in black ink. dimensions 14 cm wide × 32 cm high.
                     <lb/>very schematic dipinto of a human bust, possibly a veiled male, located in the lower right quadrant of the back wall of Bay 8. The figure is in profile toward the left with exaggerated facial features. a very large oval eye and a long, rectangular, and prominent nose are placed over a small opened mouth with a triangular upper lip. The chin is quite pronounced and the elongated neck sits over small and drooping shoulders. There are no clear indications of hair: a short and almost vertical line starting near the eye might suggest the presence of a veil whose flaps flow down at the two sides of the neck.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d8.5.xml
+++ b/output/d8.5.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d8.5.xml
+++ b/output/d8.5.xml
@@ -42,7 +42,15 @@
                     <lb/>In the center of the lower register of the bay, in black ink. dimensions 14 cm wide × 13 cm high.
                     <lb/>very small and poorly preserved dipinto of a ship sailing on starboard tack located in the cen- ter of the back wall of Bay 8, toward the bottom. Both the mast (ἱστός) and the yard (κέρας) are drawn with single lines. above the yard is visible a structure that could be identified as the καρχήσιον, the ancient equivalent of a crow’s nest from which the sailors managed the sail, obtained a distant view, or discharged missiles. The sail (ἱστίον) stretches on both sides of the yard and is connected to the bulwark by two ropes (πόδες), which possibly indicate that the vessel’s stern is to the left. no other details of the bulwark or of the oars are visible. clearly identifiable are the brailing ropes connecting the sail to the hull.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d8.6.xml
+++ b/output/d8.6.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d8.6.xml
+++ b/output/d8.6.xml
@@ -42,7 +42,15 @@
                     <lb/>In the lower left quadrant of the bay, in black ink. dimensions 5 cm wide × 6.5 cm high.
                     <lb/>very small and schematic dipinto of a human figure located in the lower left quadrant of the back wall of Bay 8. conventionally referred to as a “stick figure.” Most of the black color defin- ing the figure’s body has faded, and only a roughly oval head is still visible. The head is charac- terized by large oval eyes, a long straight nose, and a small and oval mouth tilted upward. no other details are recognizable.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d8.7.xml
+++ b/output/d8.7.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d8.7.xml
+++ b/output/d8.7.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d9.1.xml
+++ b/output/d9.1.xml
@@ -44,7 +44,15 @@
                     <lb/>size of his upper torso, the tight loincloth (subligaculum) revealing the contours of the buttocks, and the lines at his waist indicating a balteus. a helmet with a stylized element on top (a poorly rendered crest and fish?) protects his head, while at his left, partially covered by the body, is visible the outline of a long shield, possibly a scutum. The man’s left leg is visibly larger than the right one, and it is drawn in a thicker line, suggesting the presence of a greave, a customary accessory for a murmillo.
                     <lb/>similar pose and attributes can be found in one graffito from the theater of aphrodisias (lang- ner 2001: no. 761, dated to late antiquity) and another one from the paedagogium of the domus tiberiana (solin and Itkonen-Kaila, eds. 1966: no. 97, p. 133).</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d9.1.xml
+++ b/output/d9.1.xml
@@ -53,7 +53,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/d9.2.xml
+++ b/output/d9.2.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/d9.2.xml
+++ b/output/d9.2.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp100.1.xml
+++ b/output/dp100.1.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp100.1.xml
+++ b/output/dp100.1.xml
@@ -42,7 +42,15 @@
                     <lb/>on the east face of pier a100, incised. dimensions 22.5 cm wide × 25 cm high.
                     <lb/>Graffito of a ship sailing on port tack, possibly a liburna, located on the eastern face of pier a100. The graffito is partially damaged by a large gap in the plaster that has destroyed the ship’s stern and the left half of the sail. The ship is characterized by a large central mast, which is cov- ered in a motif of crisscrossing lines identifying the rigging. a set of vertical lines, also meant to represent the rigging as well as the sail’s brailing ropes, departs from the yard and reaches the ship’s deck, defining a large trapezoidal sail. above the yard, a series of diagonal lines departing from the central mast (considerably narrower than the portion visible below the yard and ter- minating in a very stylized καρχήσιον) are part of the κηροῦχοι. The keel is flat, and the prow is slightly rounded. above the gunwale is a lattice motif representing the boat’s sidescreen, sug- gesting that the liburna was of the cataphract type. The prow terminates with a short triangular στόλος with no ἀκροστόλιον above it. from the keel projects an exaggerated ἔμβολος, in the shape of a stylized penis, with a diagonal line on the tip identifying the epithelium, confirming that the vessel has to be interpreted as a navis rostrata.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp100.2.xml
+++ b/output/dp100.2.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp100.2.xml
+++ b/output/dp100.2.xml
@@ -42,7 +42,15 @@
                     <lb/>on the east face of pier a100, incised. dimensions 11 cm wide × 11 cm high.
                     <lb/>Graffito of a building, located on the eastern face of pier a100. It depicts a stylized façade of a building, possibly a temple or a basilica. The façade comprises six columns rendered with simple vertical lines, without any indications of bases or capitals, as standing on a stereobate without steps. a triangle above them represents a pediment or roof that culminates in a round shape, possibly a sculptural decoration. The façade extends further at both sides of the roofing with an additional vertical line to the left, two to the right. These lines are possibly meant to represent two portici flanking the building on its long sides.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp100.3.xml
+++ b/output/dp100.3.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp100.3.xml
+++ b/output/dp100.3.xml
@@ -42,7 +42,15 @@
                     <lb/>on the west face of pier a100, incised. dimensions overall 15.5 cm wide × 8 cm high.
                     <lb/>Graffito of three animals, located on the western face of pier a100. They all have short, linear shanks, with no indication of the hooves. The bodies are elongated rectangles and the tails are short lines pointing upward. The heads are small inverted triangles upon which are long and linear horns. They can be interpreted as stags.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp100.4.xml
+++ b/output/dp100.4.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp100.4.xml
+++ b/output/dp100.4.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp101.1.xml
+++ b/output/dp101.1.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp101.1.xml
+++ b/output/dp101.1.xml
@@ -42,7 +42,15 @@
                     <lb/>on the west face of pier a101, in black ink. dimensions upper 7 cm wide × 12 cm high; lower
                     <lb/>dipinto of two ships, located on the western face of pier a101, immediately above dipinto DP101.2. The upper ship has very minimal detailing, making its identification uncertain. It comprises a lower rectangular feature decorated with parallel vertical lines (the hull?) and two vertical lines departing from the two sides (the rigging?). The lower one is seen from the back, as if sailing away from the viewer. The motif is rendered in stylized geometric shapes. The ship’s hull is a long narrow rectangle, terminating to the right and to the left in two inverted triangles, the ship’s rudders. at the center, a very long vertical line, prolonged even below the keel, defines the mast. a short yard runs perpendicular to the mast at three quarters of its height. a short rectangular sail is attached to it. no rigging is visible.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp101.2.xml
+++ b/output/dp101.2.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp101.2.xml
+++ b/output/dp101.2.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp102.1.xml
+++ b/output/dp102.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp102.1.xml
+++ b/output/dp102.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp103.1.xml
+++ b/output/dp103.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp103.1.xml
+++ b/output/dp103.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp104.1.xml
+++ b/output/dp104.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp104.1.xml
+++ b/output/dp104.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp105.1.xml
+++ b/output/dp105.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp105.1.xml
+++ b/output/dp105.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp112.1.xml
+++ b/output/dp112.1.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp112.1.xml
+++ b/output/dp112.1.xml
@@ -42,7 +42,15 @@
                     <lb/>on the south face of pier a112, incised. dimensions at top 47 cm wide × 8.5 cm high; at bottom, 47 cm wide × 13 cm high.
                     <lb/>Graffito  of  two  ships,  located  on  the  southern  face  of  pier  a112,  looking  into  the  Basili- ca’s  southern  corridor.  The  two  vessels,  one  on  top  of  the  other,  are  both  extremely  styl- ized,  so  that  it  is  impossible  to  discern  the  prow  from  the  stern.  Both  have  a  rockered keel  and  almost  flat  bulwark.  There  is  no  indication  of  sails,  mast,  yard,  oars,  or  rigging. In between the two boats is the hull of another ship (DP112.2); the sail of this vessel extends above the top ship of graffito DP112.1.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp112.2.xml
+++ b/output/dp112.2.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp112.2.xml
+++ b/output/dp112.2.xml
@@ -42,7 +42,15 @@
                     <lb/>on the south face of pier a112, incised. dimensions 29 cm wide × 36 cm high.
                     <lb/>Graffito of a ship, located on the southern face of pier a112, looking into the Basilica’s southern corridor. The sails of the ship are placed immediately above the upper ship in graffito DP112.1, while the hull is in between those two vessels (see graffito DP112.1). The hull of this ship is very schematic; it is thus difficult to discern the prow from the stern. a short diagonal line to the left might suggest the presence of a rudder, in which case the ship would be sailing on port tack. The keel is mostly flat, and the prow is raised, culminating in a cheniscus (ἀκροστόλιον) curv- ing inward. no oars are visible. a large lacuna above the hull has destroyed most of the lower part of the mast. The mast’s upper half is composed of a thin vertical line that is crossed at a 90-degree angle by a long and straight yard. at the yard’s extremities begin two diagonal lines that converge at the top of the mast: they are the χηροῦχοι, ropes that allowed hoisting the yard and the sail to the required height. The sail, in the shape of an inverted triangle, is decorated with rows of checkerboard motifs that are meant to depict the folds of the sail and the rigging.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp112.3.xml
+++ b/output/dp112.3.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp112.3.xml
+++ b/output/dp112.3.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp12.1.xml
+++ b/output/dp12.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp12.1.xml
+++ b/output/dp12.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp155.1.xml
+++ b/output/dp155.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp155.1.xml
+++ b/output/dp155.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp32.1.xml
+++ b/output/dp32.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp32.1.xml
+++ b/output/dp32.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp34.1.xml
+++ b/output/dp34.1.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp34.1.xml
+++ b/output/dp34.1.xml
@@ -42,7 +42,15 @@
                     <lb/>on the south face of pier a34, between Bays 22 and 23, incised. dimensions 5 cm diameter.
                     <lb/>Graffito of two circles located on the southern face of pier a34, between Bay 22 and Bay 23, looking into the Basilica’s north corridor. The circles are plain, with no other decoration inside or around them. considering their regular shape and identical size, they were certainly incised with the help of a compass.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp34.2.xml
+++ b/output/dp34.2.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp34.2.xml
+++ b/output/dp34.2.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp74.1.xml
+++ b/output/dp74.1.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp74.1.xml
+++ b/output/dp74.1.xml
@@ -42,7 +42,15 @@
                     <lb/>on the east face of pier a74, incised. dimensions as preserved: 42 cm wide × 59 cm high.
                     <lb/>Graffito of a ship, located on the eastern face of pier a74. The graffito is damaged by two large lacunae in the plaster, so that both the upper portion of the ship’s sails and the prow have com- pletely vanished. The ship, a mid-sized commercial vessel sailing on port tack, is characterized by a flat keel and a pointed stern. from the stern project the very large and rectangular blades of the two πηδάλια. a long straight line running parallel to the hull suggests the presence of a deck. The central mast is disproportionately large and decorated with horizontal lines indicat- ing the rigging. crisscrossing motifs set on both sides of the mast indicate the sail. considering the different orientations in the two sets of motifs, the drawing is meant to show two separate sails connected to the same mast. due to a gap in the plaster, the yard and the upper portion of the sails are not preserved. no oars are visible.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp74.2.xml
+++ b/output/dp74.2.xml
@@ -52,7 +52,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp74.2.xml
+++ b/output/dp74.2.xml
@@ -43,7 +43,15 @@
                     <lb/>dipinto of the upper half of a human figure, seen frontally, located on the western face of pier a74. The image was later partially obliterated by a large dipinto of a ship, of which traces of a very tall ἀκροστόλιον are the only elements still extant. The figure, very crudely made, can be identified as a gladiator, possibly a thraex. recognizable is the tall helmet with the head of the griffon seen frontally, a crescent-shaped crest, and large brims. The rather thin arms are at the side of the body, of which only the upper part of the bust is visible. no weapon or shield is visible.
                     <lb/>for a possible comparison of a gladiator with a similar helmet surmounted by a griffon from a gravestone found in smyrna, see petzl 1974: 293, no. 12.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp74.3.xml
+++ b/output/dp74.3.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp74.3.xml
+++ b/output/dp74.3.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp75.1.xml
+++ b/output/dp75.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp75.1.xml
+++ b/output/dp75.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp76.1.xml
+++ b/output/dp76.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp76.1.xml
+++ b/output/dp76.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp78.1.xml
+++ b/output/dp78.1.xml
@@ -43,7 +43,15 @@
                     <lb/>Graffito of two ships, located on the western face of pier a78. Both ships are incomplete, as the plaster has fallen off most of the pier’s surface. The ship at the top is very schematic, so that it is impossible to discern the prow from the stern. The keel is rockered, and both prow and stern are missing the usual decorative finials (i.e., aplustre and cheniscus). The bulwark is slightly concave. a parallel line running above it might indicate the presence of an upper deck. The central mast is rendered in a thin vertical line. no oars, sail, or rigging are visible.
                     <lb/>The ship to the bottom is sailing on starboard tack. The keel is slightly rockered, and the stern is slightly raised but without an aplustre, while the prow is not visible due to a lacuna in the plaster. at the stern, the two rudders (πηδάλια) are reduced to two short diagonal lines. The central mast is extremely tall. no sails, rigging, or oars are visible.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp78.1.xml
+++ b/output/dp78.1.xml
@@ -52,7 +52,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp78.2.xml
+++ b/output/dp78.2.xml
@@ -52,7 +52,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp78.2.xml
+++ b/output/dp78.2.xml
@@ -43,7 +43,15 @@
                     <lb/>Graffito of a πέλεκυς (or labrys), located on the northern face of pier a78, looking into the Basilica’s northern corridor. The graffito is made of a herringbone pattern of etched lines that defines both the ax’s haft and head. The outline is rendered with deeper and wider etched lines. The whole ax is covered in red color, probably applied after the incision. The haft is straight and slightly tapering toward the top. The head is rather straight at the top and concave at the bot- tom. The two rounded blades are symmetrical.
                     <lb/>The iconography of this graffito is very similar to that of graffito D10.1. The survival in late antiquity of the iconography of the labrys as a symbol of paganism referring to the carian Zeus has been recently discussed by angelos chaniotis in relation to a graffito found at aphro- disias; see chaniotis 2014: 16–21, esp. fig. 16, p. 21.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp78.3.xml
+++ b/output/dp78.3.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp78.3.xml
+++ b/output/dp78.3.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp81.1.xml
+++ b/output/dp81.1.xml
@@ -43,7 +43,15 @@
                     <lb/>Graffito of a rosette, located on the southern face of pier a81, looking into the Basilica’s south- ern corridor. The motif comprises six petals, two of which are incomplete, and the preparatory circle into which the rosette was fitted. considering the precise outline of the circumference, the clearly marked center, and two arcs that defines some of the petals and that extend beyond the outline, it is evident that this is not a freehand graffito, but rather it was made with a tracing tool, such as a compass. see also graffiti DP81.2 and DP32.1.
                     <lb/>similar rosettes, some incised with the aid of a compass, others not, are common in pompeii, delos, and in the domus tiberiana. for the sake of brevity, I will mention here a few examples from each site (a complete catalogue can be found in langner 2001).  similar to the rosette in smyrna is the graffito on one of the columns of the “Grande palestra” (Maulucci vivolo 1993: 64–5). even closer in shape and technical execution are the rosette on one of the walls of the caserma dei Gladiatori and those on the external wall of the casa dei cei: Maulucci vivolo</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp81.1.xml
+++ b/output/dp81.1.xml
@@ -52,7 +52,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp81.2.xml
+++ b/output/dp81.2.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp81.2.xml
+++ b/output/dp81.2.xml
@@ -42,7 +42,15 @@
                     <lb/>on the south face of pier a81, incised. diameter of each circle 18 cm.
                     <lb/>Graffito of four interlocking circles, located on the southern face of pier a81, looking into the Basilica’s southern corridor. The graffito is partially covered by the buttressing structure added to the pier in the latest phase of the basilica’s occupation. still visible are four incised circles, drawn with the help of a compass: the centers of the two fully preserved circles are clearly marked and their circumferences are identical. They were most probably incised as guidelines for the insertions of rosette motifs (see graffiti DP81.1 and DP32.1).</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp81.3.xml
+++ b/output/dp81.3.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp81.3.xml
+++ b/output/dp81.3.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp83.1.xml
+++ b/output/dp83.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp83.1.xml
+++ b/output/dp83.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp84.5.xml
+++ b/output/dp84.5.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp84.5.xml
+++ b/output/dp84.5.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp85.1.xml
+++ b/output/dp85.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp85.1.xml
+++ b/output/dp85.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp93.1.xml
+++ b/output/dp93.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp93.1.xml
+++ b/output/dp93.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp94.1.xml
+++ b/output/dp94.1.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp94.1.xml
+++ b/output/dp94.1.xml
@@ -42,7 +42,15 @@
                     <lb/>on the west face of pier a94, in black ink. dimensions 46 cm wide × 61 cm high.
                     <lb/>dipinto of a bird, located on the western face of pier a94. It is damaged at the bottom, where the plaster has detached from the pier, and the ink is largely faded. what is extant is the elon- gated and curved neck and long beak of a bird, possibly a swan.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp94.2.xml
+++ b/output/dp94.2.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp94.2.xml
+++ b/output/dp94.2.xml
@@ -42,7 +42,15 @@
                     <lb/>on the west face of pier a94, in black and red ink. dimensions 34 cm wide × 40 cm high.
                     <lb/>dipinto of a ship, located on the western face of pier a94. only the upper part of the vessel is still extant, as the plaster below has detached from the wall. still visible are the red sail, deco- rated with a checkerboard motif, the red horizontal yard, and the upper portion of the black mast.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp94.3.xml
+++ b/output/dp94.3.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp94.3.xml
+++ b/output/dp94.3.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/dp96.1.xml
+++ b/output/dp96.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/dp96.1.xml
+++ b/output/dp96.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t10.1.xml
+++ b/output/t10.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t10.1.xml
+++ b/output/t10.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>In a tabula ansata ca. 26 cm wide × 26 cm high. scattered letters 2 cm high, with a theta or epsilon at the start of the first line.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t10.2.xml
+++ b/output/t10.2.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t10.2.xml
+++ b/output/t10.2.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>on the central wall of the bay, to the left of the door. area 24 cm wide × 22 cm high. very faint detached, informal letters 2 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t11.1.xml
+++ b/output/t11.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>ending 42 cm from the right side of the bay, and about 2.15 m above ground level. above the phallus D11.5 and to the right of the testicles. area of 32 cm wide × 12 cm high. letters 7–11 cm high, crudely written.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t11.1.xml
+++ b/output/t11.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t11.2.xml
+++ b/output/t11.2.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t11.2.xml
+++ b/output/t11.2.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>under the phallus, an area of 19 cm wide × 7 cm high. 2 lines in rough capitals 3 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t11.3.xml
+++ b/output/t11.3.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t11.3.xml
+++ b/output/t11.3.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>lower on the panel, below the ship drawing. Bottom of inscription ca. 90 cm from the ground, 64 cm from left edge. area 40 cm wide × 57 cm high. very irregular, rather cursive letters mainly 4–5 cm high. The inscription is very intermingled with drawing and it is not easy to tell what is letters and what is drawing, nor whether the letters all belong to a single inscription. remains of 9 lines in all.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t11.4.xml
+++ b/output/t11.4.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t11.4.xml
+++ b/output/t11.4.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>on the pier at right, at top, an area of 10 cm wide × 9 cm high, with incised majuscule letters 4 cm in height.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t12.1.xml
+++ b/output/t12.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t12.1.xml
+++ b/output/t12.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>large tabula ansata with four lines. In the upper part of the bay, at the left side, about 1.58 m above the bench level. area 61 cm wide × 49 cm high. letters 8 cm high, in neat, spaced block capitals.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t12.2.xml
+++ b/output/t12.2.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t12.2.xml
+++ b/output/t12.2.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>four lines. area ca. 80 cm wide × 20 cm high. detached, neat, rounded letters 3–4 cm high. Badly effaced at the right side.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t12.5.xml
+++ b/output/t12.5.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>Immediately above T12.4 and its drawing. area 37 cm wide × 10 cm high. Irregular, detached, informal letters 3–4 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t12.5.xml
+++ b/output/t12.5.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t13.3.xml
+++ b/output/t13.3.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t13.3.xml
+++ b/output/t13.3.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>at the top of the preserved area, 31 cm from the left edge of the bay. area 60 cm wide × 54 cm high as preserved; broken at right and particularly upper right. Majuscule letters 5–7 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t13.4.xml
+++ b/output/t13.4.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t13.4.xml
+++ b/output/t13.4.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t14.2.xml
+++ b/output/t14.2.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t14.2.xml
+++ b/output/t14.2.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>about 10 cm below T14.1 and just to the right. area 40 × 3 cm. detached majuscule letters 5 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t15.10.xml
+++ b/output/t15.10.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t15.10.xml
+++ b/output/t15.10.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>on the face of the pier at left (a25), at the top of the surviving plaster; overall dimensions 32 cm high × 30 cm wide; broken at top. ungainly majuscule letters 5–6 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t16.1.xml
+++ b/output/t16.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t16.1.xml
+++ b/output/t16.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>at top, centered, 27 cm from the top of the wall, 35 cm from the left edge. area 75 cm wide × 37 cm high. detached roughly made majuscule letters 4–6 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t16.2.xml
+++ b/output/t16.2.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t16.2.xml
+++ b/output/t16.2.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>at 13 cm from the left edge, 84 cm above the bench, at left of a badly effaced drawing. area 8 cm wide × 12 cm high. letters 4–6 cm high. The boundaries are unclear, and there are other ink traces that could belong to this inscription.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t20.1.xml
+++ b/output/t20.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>at ca. 1.56 m from the top of the bench and 30 cm from the left side. area ca. 30 cm wide × 18 cm high. Irregular detached majuscule letters of line 1 are 3–4 cm high; those of line 2, 4–6 cm high. not enough survives of line 3 to measure.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t20.1.xml
+++ b/output/t20.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t20.3–4.xml
+++ b/output/t20.3–4.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t20.3–4.xml
+++ b/output/t20.3–4.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>These inscriptions occupy a large box divided by a horizontal line. Its right edge is 16 cm from the right of the bay; its top is broken off; its bottom is 1.2 m above the bench. The width is not fully preserved but was greater than 55 cm. The height of the top box is &gt; 34 cm. The height of the bottom box is 30 cm. detached, irregular rounded majuscule letters 2–3 cm high in waver- ing lines, representing two or more hands.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t21.1.xml
+++ b/output/t21.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t21.1.xml
+++ b/output/t21.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>In a tabula ansata, 28 cm wide × 16 cm high. large block capitals, 8 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t22.1.xml
+++ b/output/t22.1.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t22.1.xml
+++ b/output/t22.1.xml
@@ -42,7 +42,15 @@
                     <lb/>on the front (south) face of the pier (a34), about 1.25 m above ground level. area 16 cm wide
                     <lb/>× 7 cm high, incised in letters 1.5–2.5 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t22.2.xml
+++ b/output/t22.2.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t22.2.xml
+++ b/output/t22.2.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>area 22 cm wide × 11 cm high. about 6 cm above 22.1 in incised letters 6 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t22.3.xml
+++ b/output/t22.3.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t22.3.xml
+++ b/output/t22.3.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>at the top of the face of pier a34, just below the breaking off of the plaster, three lines occupy- ing an area 30 cm wide × 10 cm high are incised in letters 2 cm high; also some large red letters not yet read. we can offer a text for only line 3.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t24.1.xml
+++ b/output/t24.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t24.1.xml
+++ b/output/t24.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>at 15 cm from the left edge, ca. 1.18 m above the bench. area ca. 25 cm wide × 18 cm high. rather awkward capital letters 3–4 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t24.2.xml
+++ b/output/t24.2.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t24.2.xml
+++ b/output/t24.2.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>ca. 15 cm to the right of the right edge of T24.1 and just above one testicle of D24.1. one inscription with fragments of a second to its right; overall area ca. &gt;54 cm wide × 18 cm high. cursive-style but detached letters 4–7 cm high on the left. The highly effaced surface leaves doubt about how many inscriptions are at stake.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t24.5.xml
+++ b/output/t24.5.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t24.5.xml
+++ b/output/t24.5.xml
@@ -42,7 +42,15 @@
                     <lb/>on left pier (a35), at top, isolated letters in a space 14 cm wide × 9 cm high. surface broken at right. letters 5 cm high.
                     <lb/>× 28 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t25.2.xml
+++ b/output/t25.2.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t25.2.xml
+++ b/output/t25.2.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>Just to the left of the lower part of the box of T25.1, 10 cm from the left edge. Just below it is the drawing of a youth’s head (D25.4), presumably the intended “speaker” of the word. detached letters ca. 2–2.5 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t25.3.xml
+++ b/output/t25.3.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>at the right side, 1.54 m above ground level, abutting the right edge of the bay. area ca. 67 cm wide × 14 cm high, but possibly incomplete at left. The left part of the inscription and the right part are written in different hands, but it is not certain that they are unrelated. letters irregular, 4–10 cm high. The last four letters of line 1 and the last two letters of line 2 are written in a less cursive, larger, and heavier hand.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t25.3.xml
+++ b/output/t25.3.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t25.5.xml
+++ b/output/t25.5.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t25.5.xml
+++ b/output/t25.5.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>at the top of the wall, against the right edge of the bay. area ca. 40 cm wide × 10 cm high. Irregular detached letters 4 cm high except rho and high nu, which are 7 cm.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t27.1.xml
+++ b/output/t27.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>at 14 cm from the left edge of the bay, ca. 1.85 m above ground level. area 18 cm wide × 29 cm high. an awkward mixture of cursive and capital forms, wavery and variable in size; letters 4–6 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t27.1.xml
+++ b/output/t27.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t27.2.xml
+++ b/output/t27.2.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t27.2.xml
+++ b/output/t27.2.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>Immediately to the right of T27.1, at 38 cm from the left side of the bay and 1.85 m above the ground level. stylish letters, detached but cursive in style, 4–6 cm high. at the right end of line 1 it is impossible to distinguish the letter strokes from the rigging of the ship drawing immedi- ately below (D27.1).</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t27.3.xml
+++ b/output/t27.3.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t27.3.xml
+++ b/output/t27.3.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>on the right edge of the bay, 8 cm from the right and ca. 1.85 m from ground level. area 34 cm wide × 8 cm high. detached letters 3–4 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t28.1.xml
+++ b/output/t28.1.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t28.1.xml
+++ b/output/t28.1.xml
@@ -42,7 +42,15 @@
                     <lb/>about 1.50 m above ground level and 10 cm from the left edge of the bay. area ca 40 cm wide
                     <lb/>× 30 cm high, in box. detached capital letters 4–5 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t29.5.xml
+++ b/output/t29.5.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>located 15 cm below T29.2 at a slant upward to the right. written on the right testicle of D29.7. large rough capital letters 5–6 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t29.5.xml
+++ b/output/t29.5.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t29.7.xml
+++ b/output/t29.7.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t29.7.xml
+++ b/output/t29.7.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>on the right pier (a41), on the edge between the side facing the bay and the outer pier face, about 10 cm from the top of the surviving wall above a drawing. area 24 cm wide × 18 cm high. large majuscule letters 8 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t29.8.xml
+++ b/output/t29.8.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t29.8.xml
+++ b/output/t29.8.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>about 40 cm above T29.3, one line occupying a space 33 cm wide × 4 cm high. letters 3–4 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t30.1.xml
+++ b/output/t30.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t30.1.xml
+++ b/output/t30.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>above the top of the gateway, in an area 30 cm wide × 25 cm high, in one line, letters 4–8 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t30.2.xml
+++ b/output/t30.2.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t30.2.xml
+++ b/output/t30.2.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t38.1.xml
+++ b/output/t38.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t38.1.xml
+++ b/output/t38.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t42.1.xml
+++ b/output/t42.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t42.1.xml
+++ b/output/t42.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>on the face of the pier at left (pier a53). Incised. 159 cm from floor. on the first layer of plaster. large letters, 1.8–3 cm high. small letters, 0.5 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/t9.9.xml
+++ b/output/t9.9.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/t9.9.xml
+++ b/output/t9.9.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>Below T9.8, a tabula ansata 17 cm wide × 21 cm high, with space for 6 lines; only the begin- nings of lines 1–5 are now visible, with a few very faint letters 1.5–2 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp100.1.xml
+++ b/output/tp100.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp100.1.xml
+++ b/output/tp100.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>on the south face, at 15 cm below the top of the plaster. area 9 cm wide × 6 cm high. Incised detached letters 2 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp100.2.xml
+++ b/output/tp100.2.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp100.2.xml
+++ b/output/tp100.2.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>to the right of TP100.1. area 9 cm wide × 6 cm high, with detached, incised letters 2 cm high, evidently the same writer as TP100.1.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp100.3.xml
+++ b/output/tp100.3.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp100.3.xml
+++ b/output/tp100.3.xml
@@ -42,7 +42,15 @@
                     <lb/>on the bevel to the right of the south side, at the same height as TP100.1 and TP100.2. on the lower layer of plaster. possibly two separate inscriptions but in the same hand. area 15 cm wide
                     <lb/>× 10 cm high, starting at 12 cm from the left edge. detached letters 1 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp100.4.xml
+++ b/output/tp100.4.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp100.4.xml
+++ b/output/tp100.4.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp100.5.xml
+++ b/output/tp100.5.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp100.5.xml
+++ b/output/tp100.5.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>above TP100.1 and about 155 cm above ground level. area 42 cm wide × 11 cm high. Incised majuscule letters 6 cm (minimum) high in first line and 4 cm in second line. The plaster is broken above line 1, taking the tops of some letters. a cross-hatched pattern makes it difficult in line 1 to distinguish what are letters and what not.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp100.6.xml
+++ b/output/tp100.6.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp100.6.xml
+++ b/output/tp100.6.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp100.7.xml
+++ b/output/tp100.7.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp100.7.xml
+++ b/output/tp100.7.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp103.1.xml
+++ b/output/tp103.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp103.1.xml
+++ b/output/tp103.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>on the underside of the arch. area 14 cm wide × 40 cm high. two stars (DP103.1) and an inscription in cursive but detached letters 3–5 cm high. on the second layer of the plaster.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp103.2.xml
+++ b/output/tp103.2.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp103.2.xml
+++ b/output/tp103.2.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>to the left of TP103.1, in the recessed area, 230 cm from floor. on the second layer of the plas- ter. area 14 cm high × 43 cm wide. letters 4 cm.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp103.3.xml
+++ b/output/tp103.3.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp103.3.xml
+++ b/output/tp103.3.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>to the left of TP103.2. In the recessed area. 203 cm from floor. area 23 cm wide × 21 cm high. on the second layer of the plaster. letters 4.5 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp104.1.xml
+++ b/output/tp104.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp104.1.xml
+++ b/output/tp104.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp104.2.xml
+++ b/output/tp104.2.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp104.2.xml
+++ b/output/tp104.2.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>on the south face of the pier, at the very top of preserved plaster. not reached for measure- ments, and not read.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp105.1.xml
+++ b/output/tp105.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>west face. area ca. 30 cm wide × 90 cm high. large detached letters with a modicum of style, 8–13 cm high. Below, a drawing (DP105.1).</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp105.1.xml
+++ b/output/tp105.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp109.1.xml
+++ b/output/tp109.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp109.1.xml
+++ b/output/tp109.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>Below and to the left of temple 1. Majuscule, informal letters, 0.5 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp109.2.xml
+++ b/output/tp109.2.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp109.2.xml
+++ b/output/tp109.2.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>another inscription stands to the left and above it, to the left of the base of temple 1; probably by the same hand.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp109.3.xml
+++ b/output/tp109.3.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp109.3.xml
+++ b/output/tp109.3.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp109.4.xml
+++ b/output/tp109.4.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp109.4.xml
+++ b/output/tp109.4.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp128.1.xml
+++ b/output/tp128.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp128.1.xml
+++ b/output/tp128.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp76.1.xml
+++ b/output/tp76.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp76.1.xml
+++ b/output/tp76.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>on the west face. 121 cm from floor, in an area 30 cm wide × 8 cm high. Incised. letters 2 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp77.1.xml
+++ b/output/tp77.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support/>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp77.1.xml
+++ b/output/tp77.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp78.1.xml
+++ b/output/tp78.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp78.1.xml
+++ b/output/tp78.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>on the south face. under the vault, in an area 30 cm wide × 6 cm high. letters 5 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp78.2.xml
+++ b/output/tp78.2.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp78.2.xml
+++ b/output/tp78.2.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>on the east face. Incised. 121 cm from floor, in an area 18 cm wide × 10 cm high. letters 0.9–1.5 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp78.3.xml
+++ b/output/tp78.3.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp78.3.xml
+++ b/output/tp78.3.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>to the left of P78.2 and just below and to the left of the drawing of a ship.  area 16 cm wide × 9 cm high. Incised letters 1–1.5 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp84.1.xml
+++ b/output/tp84.1.xml
@@ -51,7 +51,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp84.1.xml
+++ b/output/tp84.1.xml
@@ -42,7 +42,15 @@
                     <lb/>on the south face of the pier, on the upper right. Incised. 140 cm from the floor. area 7 cm wide
                     <lb/>× 12 cm high. letters 1 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp84.2.xml
+++ b/output/tp84.2.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp84.2.xml
+++ b/output/tp84.2.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>to the left of TP84.1. In an area 10 cm wide × 2.5 cm high. Incised. letters 2 cm high. Below this, another inscription with larger letters (3.5 cm).</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp84.4.xml
+++ b/output/tp84.4.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>on the west face of the pier. 125 cm from floor, in an area 7 cm wide × 2 cm high. Incised. let- ters 1.6 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp84.4.xml
+++ b/output/tp84.4.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp84.5.xml
+++ b/output/tp84.5.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp84.5.xml
+++ b/output/tp84.5.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>on the west side,  just below and to the left of TP84.4. Incised in an area 9 cm wide × 1.5 cm high. letters 1.5 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp84.7.xml
+++ b/output/tp84.7.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp84.7.xml
+++ b/output/tp84.7.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>on the east face of the pier. Incised. 120 cm from floor; to its right are some additional strokes. letters 3–5 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp93.1.xml
+++ b/output/tp93.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp93.1.xml
+++ b/output/tp93.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>on the south face of  the  pier.  near the upper left of the surviving plaster. area 21 cm wide × 6 cm high. Incised. letters 3–5 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp94.1.xml
+++ b/output/tp94.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp94.1.xml
+++ b/output/tp94.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>on the left bevel of the south face. Incised. from 131 cm from floor. area 12 cm wide × 6 cm high. letters 1.2–2.5 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp94.3.xml
+++ b/output/tp94.3.xml
@@ -43,7 +43,15 @@
                     <lb/>of three letters, only alpha is clearly visible.
                     <lb/>on the south face of the pier, at the top of the plaster. area 52 cm wide × 17 cm high; very faded letters.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp94.3.xml
+++ b/output/tp94.3.xml
@@ -52,7 +52,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp96.1.xml
+++ b/output/tp96.1.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp96.1.xml
+++ b/output/tp96.1.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>on the west face, about 125 cm above ground level. on an under layer of plaster. area ca. 30 cm wide × 25 cm high. letters 6 cm high. The inscription looks erased and the traces were barely visible in 2014.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp96.2.xml
+++ b/output/tp96.2.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp96.2.xml
+++ b/output/tp96.2.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>on the south face, on the right side of the surviving plaster. area 7 cm wide × 13 cm high. well- made, even stylish, small minuscule incised letters 1 cm high, mostly detached. along with other remains is the following.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp96.3.xml
+++ b/output/tp96.3.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp96.3.xml
+++ b/output/tp96.3.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>on the east face, ca. 115 cm above ground level. area ca. 25 × 7 cm. Incised letters 5 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>

--- a/output/tp96.4.xml
+++ b/output/tp96.4.xml
@@ -49,7 +49,10 @@
                                         </layout>
                                     </layoutDesc>
  </objectDesc>
-                    </physDesc>
+                    <handDesc>
+                                    <handNote>Letter heights: <height unit="centimeter" min="" max="" scope="letter">TK</height> cm high</handNote>
+                                </handDesc>
+ </physDesc>
                 <history>
                         <origin>
                             <origPlace>Smyrna</origPlace>

--- a/output/tp96.4.xml
+++ b/output/tp96.4.xml
@@ -40,7 +40,15 @@
                             <supportDesc>
                                 <support>east face, just below TP96.3, in area 11 cm wide × 5 cm high. Incised letters 1.5 cm high.</support>
                             </supportDesc>
-                        </objectDesc>
+                        <layoutDesc>
+                                        <layout>TK Dimensions:
+                                            <dimensions>
+                                                <height unit="centimeter">TK</height>
+                                                <width unit="centimeter">TK</width>
+                                            </dimensions>
+                                        </layout>
+                                    </layoutDesc>
+ </objectDesc>
                     </physDesc>
                 <history>
                         <origin>


### PR DESCRIPTION
Placeholder elements have been added to all files for layoutDesc and handDesc; i.e. valid XML blocks have been added but contents/text has been removed so that they can be updated individually. Fixes #8 and fixes #9.